### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 这是一个基于 [Model Context Protocol (MCP)](https://github.com/modelcontextprotocol/typescript-sdk) TypeScript SDK 的测试项目，用于演示和测试 MCP 的不同机制，包括 Resources、Tools 和 Prompts。
 
+<a href="https://glama.ai/mcp/servers/@small-tou/mcp-test">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@small-tou/mcp-test/badge" alt="Test Server MCP server" />
+</a>
+
 ## 项目特性
 
 ### 📄 Resources (资源)
@@ -176,4 +180,4 @@ MIT License
 
 - [MCP 官方文档](https://modelcontextprotocol.io)
 - [MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk)
-- [MCP 规范](https://spec.modelcontextprotocol.io/) 
+- [MCP 规范](https://spec.modelcontextprotocol.io/)


### PR DESCRIPTION
This PR adds a badge for the [MCP Test Server](https://glama.ai/mcp/servers/@small-tou/mcp-test) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@small-tou/mcp-test">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@small-tou/mcp-test/badge" alt="Test Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.